### PR TITLE
Abolition git protocol

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/system.rb
+++ b/lib/itamae/plugin/recipe/rbenv/system.rb
@@ -2,7 +2,7 @@ node.reverse_merge!(
   rbenv: {
     plugins:    {},
     rbenv_root: '/usr/local/rbenv',
-    scheme:     'git',
+    scheme:     'https',
     versions:   [],
     install_dependency: true,
     install_development_dependency: false,


### PR DESCRIPTION
The git protocol has been discontinued.
It has been replaced with the use of HTTPS.

Ref:https://github.blog/2021-09-01-improving-git-protocol-security-github/