### PR TITLE
Install libyaml for the all of RedHat distributions

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -31,10 +31,9 @@ when 'redhat', 'fedora', 'amazon' # redhat includes CentOS
   package 'gdbm-devel'
   package 'gmp-devel'
   package 'libffi-devel'
-  if node[:platform] == 'redhat' && node[:platform_version].to_f < 8.0
-    package 'libyaml-devel'
-  else
-    # rust package only provide after rhel 8
+  package 'libyaml-devel'
+  # rust package only provide after rhel 8
+  if node[:platform] == 'redhat' && node[:platform_version].to_f > 8.0
     package 'rust' # for yjit
   end
   package 'ncurses-devel'


### PR DESCRIPTION
I forgot why I removed `libyaml-devel` from CentOS 7 at https://github.com/itamae-plugins/itamae-plugin-recipe-rbenv/pull/35 (It's wrong title...)

I checked it on RHEL8, CentOS 7 and Fedora 36. `libyaml-devel` is provided the all of RedHat distributions that are maintained now. 

I removed needless condition for CentOS 7.