### PR TITLE
gdbm-devel is not available on RHEL9

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -28,7 +28,9 @@ when 'redhat', 'fedora', 'amazon' # redhat includes CentOS
   package 'bzip2'
   package 'gcc'
   package 'make'
-  package 'gdbm-devel'
+  if node[:platform] == 'redhat' && node[:platform_version].to_f < 9.0
+    package 'gdbm-devel'
+  end
   package 'gmp-devel'
   package 'libffi-devel'
   if node[:platform] == 'redhat' && node[:platform_version].to_f < 8.0


### PR DESCRIPTION
```
[rhel9.rubyci.org]  INFO :         package[gdbm-devel] installed will change from 'false' to 'true'
[rhel9.rubyci.org] ERROR :           stdout | Updating Subscription Management repositories.
[rhel9.rubyci.org] ERROR :           stdout | Unable to read consumer identity
[rhel9.rubyci.org] ERROR :           stdout |
[rhel9.rubyci.org] ERROR :           stdout | This system is not registered with an entitlement server. You can use subscription-manager to register.
[rhel9.rubyci.org] ERROR :           stdout |
[rhel9.rubyci.org] ERROR :           stdout | Last metadata expiration check: 0:22:27 ago on Thu 26 Jan 2023 07:40:23 AM UTC.
[rhel9.rubyci.org] ERROR :           stdout | No match for argument: gdbm-devel
[rhel9.rubyci.org] ERROR :           stderr | Error: Unable to find a match: gdbm-devel
[rhel9.rubyci.org] ERROR :           Command `yum -y  install gdbm-devel` failed. (exit status: 1)
[rhel9.rubyci.org] ERROR :         package[gdbm-devel] Failed.
```