### PR TITLE
Revert "Merge pull request #41 from itamae-plugins/rhel9-gdbm"

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -28,9 +28,7 @@ when 'redhat', 'fedora', 'amazon' # redhat includes CentOS
   package 'bzip2'
   package 'gcc'
   package 'make'
-  if node[:platform] == 'redhat' && node[:platform_version].to_f < 9.0
-    package 'gdbm-devel'
-  end
+  package 'gdbm-devel'
   package 'gmp-devel'
   package 'libffi-devel'
   package 'libyaml-devel'


### PR DESCRIPTION
We can install `gdbm-devel` and `libyaml-devel` after:

```
$ sudo yum-config-manager --enable codeready-builder-for-rhel-9-rhui-rpms
```