### PR TITLE
Support Raspbian (Raspberry Pi OS)

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -1,7 +1,7 @@
 # Dependencies to install x.y.z (see also: development_dependency.rb)
 # https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
 case node[:platform]
-when 'debian', 'ubuntu', 'mint'
+when 'debian', 'ubuntu', 'mint', 'raspbian'
   package 'build-essential'
   package 'libffi-dev'
   package 'libgdbm-dev'
@@ -12,6 +12,9 @@ when 'debian', 'ubuntu', 'mint'
       package 'libgdbm5'
       package 'libreadline-dev'
   elsif node[:platform] == 'debian' && (node[:platform_version].to_f >= 10.0 || node[:platform_version].include?("testing"))
+    package 'libgdbm6'
+    package 'libreadline-dev'
+  elsif node[:platform] == 'raspbian'
     package 'libgdbm6'
     package 'libreadline-dev'
   else

--- a/lib/itamae/plugin/recipe/rbenv/development_dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/development_dependency.rb
@@ -1,7 +1,7 @@
 # Dependencies to install x.y.z-dev (see also: dependency.rb)
 # https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
 case node[:platform]
-when 'debian', 'ubuntu', 'mint'
+when 'debian', 'ubuntu', 'mint', 'raspbian'
   package 'autoconf'
   package 'bison'
 when 'redhat', 'fedora', 'amazon' # redhad includes CentOS


### PR DESCRIPTION
Hello,

This pull request adds support for the Raspbian (Raspberry Pi OS).

Almost the same as Debian, but since `libgdbm3` is not available and `libreadline6-dev` is redirected to `libreadline-dev`, the following part is required.

https://github.com/itamae-plugins/itamae-plugin-recipe-rbenv/blob/ea45254cfa179aa195314a7dd5aac92bbce0b74d/lib/itamae/plugin/recipe/rbenv/dependency.rb#L17-L19

```console
$ sudo apt install libgdbm3
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package libgdbm3
```

```console
$ sudo apt install libreadline6-dev
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libreadline-dev' instead of 'libreadline6-dev'
libreadline-dev is already the newest version (8.1-1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

I checked that Ruby 3.2.0 can be installed on the following OS version.

```console
$ cat /etc/os-release 
PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
NAME="Raspbian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```

Thank you