### PR TITLE
Added support Fedora 40

### DIFF
--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -37,7 +37,8 @@ when 'redhat', 'fedora', 'amazon' # redhat includes CentOS
   package 'libffi-devel'
   package 'libyaml-devel'
   # rust package only provide after rhel 8
-  if node[:platform] == 'redhat' && node[:platform_version].to_f > 8.0
+  if node[:platform] == 'redhat' && node[:platform_version].to_f > 8.0 ||
+      node[:platform] == 'fedora' && node[:platform_version].to_i >= 28
     package 'rust' # for yjit
   end
   package 'ncurses-devel'

--- a/lib/itamae/plugin/recipe/rbenv/dependency.rb
+++ b/lib/itamae/plugin/recipe/rbenv/dependency.rb
@@ -43,7 +43,11 @@ when 'redhat', 'fedora', 'amazon' # redhat includes CentOS
   package 'ncurses-devel'
   package 'openssl-devel'
   package 'readline-devel'
-  package 'zlib-devel'
+  if node[:platform] == 'fedora' && node[:platform_version].to_i >= 40
+    package 'zlib-ng-compat-devel'
+  else
+    package 'zlib-devel'
+  end
 when 'osx', 'darwin'
   package 'libffi'
   package 'libyaml'


### PR DESCRIPTION
Fedora 40 uses `zlib-ng-compat` instead of `zlib`. 